### PR TITLE
fix: empty dataField typescript bug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,8 +29,8 @@ export default function(api: IApi, options: RequestOptions) {
         `${namespace}/request.ts`,
         requestTemplate
           .replace(/\/\*FRS\*\/(.+)\/\*FRE\*\//, formatResultStr)
-          .replace(/\['data'\]/g, `['${dataField}']`)
-          .replace(/data: T;/, `${dataField}: T;`)
+          .replace(/\['data'\]/g, dataField ? `['${dataField}']` : '')
+          .replace(/data: T;/, dataField ? `${dataField}: T;` : '')
           .replace(
             /umi-request/g,
             api.winPath(dirname(require.resolve('umi-request/package'))),

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -52,6 +52,26 @@ describe('plugin-request', () => {
     });
     expect(writeTmpFile).toHaveBeenCalled();
 
+    expect(writeTmpFile).toHaveBeenLastCalledWith(
+      'plugin-request/request.ts',
+      expect.stringContaining('type ResultWithData<T = any> = {  [key: string]: any };'),
+    );
+
+    expect(writeTmpFile).toHaveBeenLastCalledWith(
+      'plugin-request/request.ts',
+      expect.stringContaining('BaseOptions<R, P>'),
+    );
+
+    expect(writeTmpFile).toHaveBeenLastCalledWith(
+      'plugin-request/request.ts',
+      expect.stringContaining('BaseResult<R, P>'),
+    );
+
+    expect(writeTmpFile).toHaveBeenLastCalledWith(
+      'plugin-request/request.ts',
+      expect.stringContaining('result => result'),
+    );
+
     try {
       pluginFunc(getMockAPI(), {
         dataField: '&12',


### PR DESCRIPTION
修复 dataField 为空时，request.ts 生成不正确的问题

![image](https://user-images.githubusercontent.com/8576839/73922058-7aab5600-4903-11ea-8036-6242caaceef7.png)
