### PR TITLE
fix: TypeError

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -196,7 +196,7 @@ const getRequestMethod = () => {
     const { getResponse } = options;
     const resData = getResponse ? res.data : res;
     const errorInfo = errorAdaptor(resData, ctx);
-    if (errorInfo.success === false) {
+    if (errorInfo?.success === false) {
       // 抛出错误到 errorHandler 中处理
       const error: RequestError = new Error(errorInfo.errorMessage);
       error.name = 'BizError';


### PR DESCRIPTION
TypeError: Cannot read property 'success' of null

在错误监控中捕获到了一些TypeError，触发条件是后端显示的返回了 `null`即 `response.body = null` 。在不提供 `request.errorConfig.adaptor` 的情况下 `errorAdaptor(resData, ctx)` 的默认函数将不做处理的返回 `null` 值作为 `errorInfo` 变量的值。因此 `if (errorInfo.success === false) ` 将抛出TypeError。这也导致代码转移到 `errorHandler` 作为异常处理，并在页面中显示异常报错信息。