### PR TITLE
feat: Add AbortError handling

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -140,8 +140,17 @@ const getRequestMethod = () => {
         error.message = errorInfo?.errorMessage || error.message;
         error.data = error.data;
         error.info = errorInfo;
+      } else if (error.name === 'AbortError'&& error.request) {
+        const ctx: Context = {
+          req: error.request,
+          res: error.response,
+        };
+        errorInfo = errorAdaptor({}, ctx);
+        error.info = errorInfo;
       }
+      
       errorInfo = error.info;
+
 
       if (errorInfo) {
         const errorMessage = errorInfo?.errorMessage;

--- a/src/request.ts
+++ b/src/request.ts
@@ -145,7 +145,7 @@ const getRequestMethod = () => {
           req: error.request,
           res: error.response,
         };
-        errorInfo = errorAdaptor({}, ctx);
+        errorInfo = errorAdaptor(null, ctx);
         error.info = errorInfo;
       }
       


### PR DESCRIPTION
使用abort中断请求后无法进入到自定义的error adaptor
因此添加AbortError错误处理
添加AbortError测试用例


https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort